### PR TITLE
Lowercase keywords before comparison

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,7 +35,7 @@ def solveTerm(term):
         if len(term) > 1:
             return term[0] + solveTerm(term[1:])
         return term
-    if term == 'or' or term == 'and':
+    if term.lower() == 'or' or term.lower() == 'and':
         return term
     return 'nc:' + term
 


### PR DESCRIPTION
Closes https://github.com/hssm/anki-ignore-accents/issues/6

Anki started to normalize searches starting in 2.1.41: The keyword "or" is uppercased while "and" is removed.